### PR TITLE
added jquery in api to show post

### DIFF
--- a/blog/api/v1/paginations.py
+++ b/blog/api/v1/paginations.py
@@ -6,7 +6,7 @@ class DefaultPagination(PageNumberPagination):
     # page_size = 2
     # page_size_query_param = 'page_size'
     # max_page_size = 100
-    page_size = 2
+    page_size = 4
 
     def get_paginated_response(self, data):
         return Response(

--- a/blog/urls.py
+++ b/blog/urls.py
@@ -37,4 +37,6 @@ urlpatterns = [
     ),
     path("post/<int:pk>/done/", views.PostDoneView.as_view(), name="post_done"),
     path("api/v1/", include("blog.api.v1.urls", namespace="api-v1")),
+    path("post/api/", views.PostListApiView.as_view(), name="post_list_api"),
+
 ]

--- a/blog/views.py
+++ b/blog/views.py
@@ -9,6 +9,7 @@ from django.views.generic import (
     CreateView,
     UpdateView,
     DetailView,
+    TemplateView,
 )
 
 
@@ -99,3 +100,7 @@ class PostDoneView(LoginRequiredMixin, View):
         post.save()
         # print('post status update')
         return redirect(self.success_url)
+
+
+class PostListApiView(TemplateView):
+    template_name = 'blog/post_list_api.html'

--- a/core/settings.py
+++ b/core/settings.py
@@ -46,11 +46,13 @@ INSTALLED_APPS = [
     "rest_framework_simplejwt",
     "mail_templated",
     "djoser",
+    "corsheaders",
 ]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -177,3 +179,13 @@ EMAIL_HOST = "smtp4dev"
 EMAIL_HOST_USER = ""
 EMAIL_HOST_PASSWORD = ""
 EMAIL_PORT = 25
+
+
+
+# cors-headers setting
+CORS_ALLOWED_ORIGINS = [
+    # "https://example.com",
+    # "https://sub.example.com",
+    # "http://localhost:8080",
+    "http://127.0.0.1:8000",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,7 @@ coreschema==0.0.4
 Django==4.2.13
 django-filter==24.3
 djangorestframework==3.15.2
-drf-spectacular==0.28.0
-drf-yasg==1.21.8
+
 idna==3.10
 importlib_resources==6.4.5
 inflection==0.5.1
@@ -33,9 +32,7 @@ uritemplate==4.1.1
 
 
 
-drf-spectacular
-djangorestframework_simplejwt
-djoser
+
 
 
 # third party
@@ -51,4 +48,13 @@ pytest-django
 # email third party
 django-mail-templated
 
+# create fake data
 faker
+
+# api 
+drf-spectacular
+djangorestframework_simplejwt
+djoser
+drf-spectacular==0.28.0
+drf-yasg==1.21.8
+django-cors-headers

--- a/templates/blog/post_list_api.html
+++ b/templates/blog/post_list_api.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>post_list_api</title>
+</head>
+<body>
+    <h1>blog posts</h1>
+    <ol id="post-wrapper">
+    </ol>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"
+        integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ=="
+        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script>
+        $.get('/api/v1/post/',  
+            function (data, textStatus, jqXHR) { 
+                wrapper = $('#post-wrapper');
+                for (post of data.results){
+                    wrapper.append(`<li><a href="${post.absolute_url}"><h2>${post.title}</h2></a></li>`)
+                }
+            }); 
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
added cros deaders

## Summary by Sourcery

Add a new API view to display blog posts using a template and jQuery, reorganize dependencies, and enhance pagination settings.

New Features:
- Introduce a new API view 'PostListApiView' to display a list of blog posts using a template.

Enhancements:
- Increase the default page size for pagination from 2 to 4.

Build:
- Reorganize and update dependencies in requirements.txt, including re-adding drf-spectacular and drf-yasg.

Documentation:
- Add a new HTML template 'post_list_api.html' for displaying blog posts using jQuery.